### PR TITLE
Status endpoint for external app monitoring

### DIFF
--- a/app/controllers/system_statuses_controller.rb
+++ b/app/controllers/system_statuses_controller.rb
@@ -1,0 +1,8 @@
+class SystemStatusesController < ApplicationController
+
+  def show
+    Decidim::Organization.count
+    render plain: 'ok'
+  end
+
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   mount Decidim::Core::Engine => '/'
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+
+  resource :system_status, only: :show
 end

--- a/test/controllers/system_statuses_controller_test.rb
+++ b/test/controllers/system_statuses_controller_test.rb
@@ -1,0 +1,9 @@
+class SystemStatusesControllerTest < ActionDispatch::IntegrationTest
+
+  test 'show returns an OK' do
+    get '/system_status'
+    assert_response :success
+    assert_equal 'ok', @response.body
+  end
+
+end


### PR DESCRIPTION
Status endpoint to monitor if the application is up and can connect to the database.

The endpoint is: GET -> http://decidim.diba.cat/system_status