### PR TITLE
Fix installation procedure in MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ GraphicsMagick is required to be installed. For example (with `brew`): `brew ins
 - `cd decidim-diba`
 - Install dependencies: `bundle install`
 - Setup database: `bin/rails db:setup`
-- Add fake data to the database: `bin/rails db:seed`
 - Launch development server: `bin/rails server`
 
 More information can be found in the Decidim github repository: https://github.com/decidim/decidim

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ To update the Decidim installation on this project, first we update Gemfile depe
 
 ## Development
 
+**Requeriments (MacOS)**
+
+GraphicsMagick is required to be installed. For example (with `brew`): `brew install graphicsmagick`
+
 **Development environment installation**
 
 - Install development environment (Ruby 2.4+, PostgreSQL 9.4+). Check the following guide for instructions on different OS: https://gorails.com/setup/


### PR DESCRIPTION
- Add a step to install GraphicsMagick using `brew`
- Remove a step to seed the database (not required to start the app)
- TODO: do some research about why `rails db:seed` fails