### PR TITLE
Fix decidim-diba_census_api engine Docker build

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -34,6 +34,7 @@ WORKDIR $HOME
 ADD Gemfile Gemfile
 ADD Gemfile.lock Gemfile.lock
 ADD decidim-census decidim-census
+ADD decidim-diba_census_api decidim-diba_census_api
 RUN bundle install --without development test
 
 # Add the nginx site and config


### PR DESCRIPTION
The decidim-diba_census_api needs to be added before bundle install so bundler can use it when installing dependencies.