### PR TITLE
Ensure all private data is properly encoded when stored in the DB

### DIFF
--- a/app/services/diba_authorization_handler.rb
+++ b/app/services/diba_authorization_handler.rb
@@ -4,14 +4,35 @@ require 'virtus/multiparams'
 
 # An AuthorizationHandler that uses the DibaCensusApiAuthorizationHandle
 # with a fallback into the CensusAuthorizationHandler if the API fails
-class DibaAuthorizationHandler < DibaCensusApiAuthorizationHandler
+class DibaAuthorizationHandler < Decidim::AuthorizationHandler
 
   include Virtus::Multiparams
 
+  attribute :document_type, Symbol
+  attribute :id_document, String
+  attribute :birthdate, Date
+
+  validates :document_type, inclusion: { in: %i(dni nie passport) }, presence: true
+  validates :id_document, presence: true
+  validates :birthdate, presence: true
+  validate :censed
+
+  delegate :census_document_types, to: :api_handler
+  delegate :metadata, :authorized?, :unique_id, to: :diba_handler
+
   private
 
-  def census_for_user
-    super || csv_handler.census_for_user
+  def censed
+    return if diba_handler.valid?
+    errors.add(:id_document, I18n.t('decidim.census.errors.messages.not_censed'))
+  end
+
+  def diba_handler
+    @diba_handler ||= if api_handler.census_for_user
+                        api_handler
+                      else
+                        csv_handler
+                      end
   end
 
   def csv_handler
@@ -19,6 +40,13 @@ class DibaAuthorizationHandler < DibaCensusApiAuthorizationHandler
                                                     id_document: id_document,
                                                     birthdate: birthdate)
                                                .with_context(context)
+  end
+
+  def api_handler
+    @api_handler ||= DibaCensusApiAuthorizationHandler.new(user: user,
+                                                           id_document: id_document,
+                                                           birthdate: birthdate)
+                                                      .with_context(context)
   end
 
 end

--- a/db/migrate/20180301153620_encode_id_documents.decidim_census.rb
+++ b/db/migrate/20180301153620_encode_id_documents.decidim_census.rb
@@ -1,0 +1,13 @@
+# This migration comes from decidim_census (originally 20180301153440)
+class EncodeIdDocuments < ActiveRecord::Migration[5.1]
+
+  def up
+    Decidim::Census::CensusDatum.find_each do |census_datum|
+      encoded_id_document = Digest::MD5.hexdigest(
+        "#{census_datum.id_document}-#{Rails.application.secrets.secret_key_base}"
+      )
+      census_datum.update(id_document: encoded_id_document)
+    end
+  end
+
+end

--- a/db/migrate/20180301153620_encode_id_documents.decidim_census.rb
+++ b/db/migrate/20180301153620_encode_id_documents.decidim_census.rb
@@ -3,7 +3,7 @@ class EncodeIdDocuments < ActiveRecord::Migration[5.1]
 
   def up
     Decidim::Census::CensusDatum.find_each do |census_datum|
-      encoded_id_document = Digest::MD5.hexdigest(
+      encoded_id_document = Digest::SHA256.hexdigest(
         "#{census_datum.id_document}-#{Rails.application.secrets.secret_key_base}"
       )
       census_datum.update(id_document: encoded_id_document)

--- a/db/migrate/20180301162116_encode_authorization_unique_ids.rb
+++ b/db/migrate/20180301162116_encode_authorization_unique_ids.rb
@@ -4,7 +4,7 @@ class EncodeAuthorizationUniqueIds < ActiveRecord::Migration[5.1]
       'LOCK decidim_authorizations IN ACCESS EXCLUSIVE MODE'
     )
     Decidim::Authorization.find_each do |authorization|
-      encoded_unique_id = Digest::MD5.hexdigest(
+      encoded_unique_id = Digest::SHA256.hexdigest(
         "#{authorization.unique_id}-#{Rails.application.secrets.secret_key_base}"
       )
       authorization.update(unique_id: encoded_unique_id)

--- a/db/migrate/20180301162116_encode_authorization_unique_ids.rb
+++ b/db/migrate/20180301162116_encode_authorization_unique_ids.rb
@@ -1,0 +1,13 @@
+class EncodeAuthorizationUniqueIds < ActiveRecord::Migration[5.1]
+  def up
+    ActiveRecord::Base.connection.execute(
+      'LOCK decidim_authorizations IN ACCESS EXCLUSIVE MODE'
+    )
+    Decidim::Authorization.find_each do |authorization|
+      encoded_unique_id = Digest::MD5.hexdigest(
+        "#{authorization.unique_id}-#{Rails.application.secrets.secret_key_base}"
+      )
+      authorization.update(unique_id: encoded_unique_id)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180301101449) do
+ActiveRecord::Schema.define(version: 20180301162116) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/decidim-census/app/models/decidim/census/census_datum.rb
+++ b/decidim-census/app/models/decidim/census/census_datum.rb
@@ -13,15 +13,20 @@ module Decidim
       # Search for a specific document id inside a organization
       def self.search_id_document(organization, id_document)
         CensusDatum.inside(organization)
-                   .where(id_document: normalize_id_document(id_document))
+                   .where(id_document: normalize_and_encode_id_document(id_document))
                    .order(created_at: :desc, id: :desc)
                    .first
       end
 
-      # Normalizes a id document string (remove invalid characters)
-      def self.normalize_id_document(string)
-        return '' unless string
-        string.gsub(/[^A-z0-9]/, '').upcase
+      # Normalizes a id document string (remove invalid characters) and encode it
+      # to conform with Decidim privacy guidelines.
+      def self.normalize_and_encode_id_document(id_document)
+        return '' unless id_document
+        id_document = id_document.gsub(/[^A-z0-9]/, '').upcase
+        return '' if id_document.blank?
+        Digest::MD5.hexdigest(
+          "#{id_document}-#{Rails.application.secrets.secret_key_base}"
+        )
       end
 
       # Convert a date from string to a Date object

--- a/decidim-census/app/models/decidim/census/census_datum.rb
+++ b/decidim-census/app/models/decidim/census/census_datum.rb
@@ -24,7 +24,7 @@ module Decidim
         return '' unless id_document
         id_document = id_document.gsub(/[^A-z0-9]/, '').upcase
         return '' if id_document.blank?
-        Digest::MD5.hexdigest(
+        Digest::SHA256.hexdigest(
           "#{id_document}-#{Rails.application.secrets.secret_key_base}"
         )
       end

--- a/decidim-census/app/models/decidim/census/csv_data.rb
+++ b/decidim-census/app/models/decidim/census/csv_data.rb
@@ -19,8 +19,8 @@ module Decidim
       private
 
       def process_row(row)
-        id_document = Decidim::Census::CensusDatum.normalize_id_document(row[0])
-        date = Decidim::Census::CensusDatum.parse_date(row[1])
+        id_document = CensusDatum.normalize_and_encode_id_document(row[0])
+        date = CensusDatum.parse_date(row[1])
         if id_document.present? && !date.nil?
           values << [id_document, date]
         else

--- a/decidim-census/db/migrate/20180301153440_encode_id_documents.rb
+++ b/decidim-census/db/migrate/20180301153440_encode_id_documents.rb
@@ -2,7 +2,7 @@ class EncodeIdDocuments < ActiveRecord::Migration[5.1]
 
   def up
     Decidim::Census::CensusDatum.find_each do |census_datum|
-      encoded_id_document = Digest::MD5.hexdigest(
+      encoded_id_document = Digest::SHA256.hexdigest(
         "#{census_datum.id_document}-#{Rails.application.secrets.secret_key_base}"
       )
       census_datum.update(id_document: encoded_id_document)

--- a/decidim-census/db/migrate/20180301153440_encode_id_documents.rb
+++ b/decidim-census/db/migrate/20180301153440_encode_id_documents.rb
@@ -1,0 +1,12 @@
+class EncodeIdDocuments < ActiveRecord::Migration[5.1]
+
+  def up
+    Decidim::Census::CensusDatum.find_each do |census_datum|
+      encoded_id_document = Digest::MD5.hexdigest(
+        "#{census_datum.id_document}-#{Rails.application.secrets.secret_key_base}"
+      )
+      census_datum.update(id_document: encoded_id_document)
+    end
+  end
+
+end

--- a/decidim-census/spec/controllers/censuses_controller_spec.rb
+++ b/decidim-census/spec/controllers/censuses_controller_spec.rb
@@ -39,8 +39,10 @@ RSpec.describe Decidim::Census::Admin::CensusesController,
       expect(response).to have_http_status(:redirect)
 
       expect(Decidim::Census::CensusDatum.count).to be 3
-      expect(Decidim::Census::CensusDatum.first.id_document).to eq '1111A'
-      expect(Decidim::Census::CensusDatum.last.id_document).to eq '3333C'
+      expect(Decidim::Census::CensusDatum.first.id_document)
+        .to eq encode_id_document('1111A')
+      expect(Decidim::Census::CensusDatum.last.id_document)
+        .to eq encode_id_document('3333C')
     end
   end
 

--- a/decidim-census/spec/helpers.rb
+++ b/decidim-census/spec/helpers.rb
@@ -1,0 +1,11 @@
+module Decidim
+  module Census
+    module Helpers
+      def encode_id_document(id_document)
+        Digest::MD5.hexdigest(
+          "#{id_document}-#{Rails.application.secrets.secret_key_base}"
+        )
+      end
+    end
+  end
+end

--- a/decidim-census/spec/helpers.rb
+++ b/decidim-census/spec/helpers.rb
@@ -2,7 +2,7 @@ module Decidim
   module Census
     module Helpers
       def encode_id_document(id_document)
-        Digest::MD5.hexdigest(
+        Digest::SHA256.hexdigest(
           "#{id_document}-#{Rails.application.secrets.secret_key_base}"
         )
       end

--- a/decidim-census/spec/models/census_datum_spec.rb
+++ b/decidim-census/spec/models/census_datum_spec.rb
@@ -6,15 +6,16 @@ RSpec.describe Decidim::Census::CensusDatum, type: :model do
   CensusDatum = Decidim::Census::CensusDatum
 
   describe 'get census for a given identity document' do
+
     it 'returns the last inserted when duplicates' do
-      FactoryBot.create(:census_datum, id_document: 'AAA')
-      last = FactoryBot.create(:census_datum, id_document: 'AAA',
+      FactoryBot.create(:census_datum, id_document: encode_id_document('AAA'))
+      last = FactoryBot.create(:census_datum, id_document: encode_id_document('AAA'),
                                               organization: organization)
       expect(CensusDatum.search_id_document(organization, 'AAA')).to eq(last)
     end
 
     it 'normalizes the document' do
-      census = FactoryBot.create(:census_datum, id_document: 'AAA',
+      census = FactoryBot.create(:census_datum, id_document: encode_id_document('AAA'),
                                                 organization: organization)
       expect(CensusDatum.search_id_document(organization, 'a-a-a')).to eq(census)
     end
@@ -28,11 +29,13 @@ RSpec.describe Decidim::Census::CensusDatum, type: :model do
   end
 
   describe 'normalization methods' do
-    it 'normalizes id document' do
-      expect(CensusDatum.normalize_id_document('1234a')).to eq '1234A'
-      expect(CensusDatum.normalize_id_document('   1234a  ')).to eq '1234A'
-      expect(CensusDatum.normalize_id_document(')($·$')).to eq ''
-      expect(CensusDatum.normalize_id_document(nil)).to eq ''
+    it 'normalizes and encodes the id document' do
+      expect(CensusDatum.normalize_and_encode_id_document('1234a'))
+        .to eq encode_id_document('1234A')
+      expect(CensusDatum.normalize_and_encode_id_document('   1234a  '))
+        .to eq encode_id_document('1234A')
+      expect(CensusDatum.normalize_and_encode_id_document(')($·$')).to eq ''
+      expect(CensusDatum.normalize_and_encode_id_document(nil)).to eq ''
     end
 
     it 'normalizes dates' do

--- a/decidim-census/spec/models/csv_data_spec.rb
+++ b/decidim-census/spec/models/csv_data_spec.rb
@@ -3,9 +3,12 @@ RSpec.describe Decidim::Census::CsvData do
     file = file_fixture('data1.csv')
     data = Decidim::Census::CsvData.new(file)
     expect(data.values.length).to be 3
-    expect(data.values[0]).to eq ['1111A', Date.strptime('1981/01/01', '%Y/%m/%d')]
-    expect(data.values[1]).to eq ['2222B', Date.strptime('1982/02/02', '%Y/%m/%d')]
-    expect(data.values[2]).to eq ['3333C', Date.strptime('2017/01/01', '%Y/%m/%d')]
+    expect(data.values[0])
+      .to eq [encode_id_document('1111A'), Date.strptime('1981/01/01', '%Y/%m/%d')]
+    expect(data.values[1])
+      .to eq [encode_id_document('2222B'), Date.strptime('1982/02/02', '%Y/%m/%d')]
+    expect(data.values[2])
+      .to eq [encode_id_document('3333C'), Date.strptime('2017/01/01', '%Y/%m/%d')]
   end
 
   it 'returns the number of errored rows' do

--- a/decidim-census/spec/services/census_authorization_handler_spec.rb
+++ b/decidim-census/spec/services/census_authorization_handler_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe CensusAuthorizationHandler do
   let(:organization) { FactoryBot.create(:organization) }
   let(:user) { FactoryBot.create(:user, organization: organization) }
   let(:dni) { '1234A' }
+  let(:encoded_dni) { encode_id_document(dni) }
   let(:date) { Date.strptime('1990/11/21', '%Y/%m/%d') }
   let(:handler) do
     CensusAuthorizationHandler.new(id_document: dni, birthdate: date)
@@ -12,7 +13,7 @@ RSpec.describe CensusAuthorizationHandler do
   end
 
   let(:census_datum) do
-    FactoryBot.create(:census_datum, id_document: dni,
+    FactoryBot.create(:census_datum, id_document: encoded_dni,
                                      birthdate: date,
                                      organization: organization)
   end

--- a/decidim-census/spec/spec_helper.rb
+++ b/decidim-census/spec/spec_helper.rb
@@ -6,6 +6,11 @@ require 'decidim/core'
 require 'decidim/verifications'
 require 'decidim/core/test'
 require 'social-share-button'
+require 'helpers'
+
+RSpec.configure do |c|
+  c.include Decidim::Census::Helpers
+end
 
 ENV['ENGINE_NAME'] = File.dirname(__dir__).split('/').last
 

--- a/decidim-diba_census_api/app/services/diba_census_api_authorization_handler.rb
+++ b/decidim-diba_census_api/app/services/diba_census_api_authorization_handler.rb
@@ -42,7 +42,7 @@ class DibaCensusApiAuthorizationHandler < Decidim::AuthorizationHandler
 
   def unique_id
     return unless census_for_user
-    Digest::MD5.hexdigest(
+    Digest::SHA256.hexdigest(
       "#{census_for_user.id_document}-#{Rails.application.secrets.secret_key_base}"
     )
   end

--- a/decidim-diba_census_api/app/services/diba_census_api_authorization_handler.rb
+++ b/decidim-diba_census_api/app/services/diba_census_api_authorization_handler.rb
@@ -41,7 +41,10 @@ class DibaCensusApiAuthorizationHandler < Decidim::AuthorizationHandler
   end
 
   def unique_id
-    census_for_user&.id_document
+    return unless census_for_user
+    Digest::MD5.hexdigest(
+      "#{census_for_user.id_document}-#{Rails.application.secrets.secret_key_base}"
+    )
   end
 
   def census_for_user
@@ -53,7 +56,6 @@ class DibaCensusApiAuthorizationHandler < Decidim::AuthorizationHandler
       document_type: document_type_code,
       id_document: id_document
     )
-    @census_for_user
   end
 
   private


### PR DESCRIPTION
When uploading a census file with document numbers or using a
document_id as the unique_id of an authorization handler, we are now
encoding those values.

Migrations have been included to migrate all existant data.