### PR TITLE
Fix Faker version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ group :development, :test do
   gem 'decidim-dev', '~> 0.9.3'
   gem 'dotenv-rails'
   gem 'factory_bot_rails'
-  gem 'faker', '~> 1.7.3'
+  gem 'faker'
   gem 'pry-byebug'
   gem 'pry-coolline'
   gem 'pry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -296,8 +296,8 @@ GEM
     factory_bot_rails (4.8.2)
       factory_bot (~> 4.8.2)
       railties (>= 3.0.0)
-    faker (1.7.3)
-      i18n (~> 0.5)
+    faker (1.8.7)
+      i18n (>= 0.7)
     faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.23)
@@ -670,7 +670,7 @@ DEPENDENCIES
   decidim-diba_census_api!
   dotenv-rails
   factory_bot_rails
-  faker (~> 1.7.3)
+  faker
   letter_opener_web
   listen (~> 3.1.0)
   pry-byebug


### PR DESCRIPTION
- Remove the faker's version and update.

When we do a `db:seed` an error rises because it uses a new Faker method