### PR TITLE
[DOC] Fix mispelling.

### DIFF
--- a/decidim-ldap/README.md
+++ b/decidim-ldap/README.md
@@ -1,6 +1,6 @@
 # Decidim::Ldap
 
-A decidim package to provice user authentication via LDAP. Once is active for an organization,
+A decidim package to provide user authentication via LDAP. Once is active for an organization,
 it is imposible to signup.
 
 The plugin adds a new tab in the Decidim System admin panel that allows to create LDAP configurations

--- a/lib/tasks/ldap_server.rake
+++ b/lib/tasks/ldap_server.rake
@@ -1,6 +1,7 @@
 namespace :ldap do
   desc 'Starts a new ldap server with Ladle'
   task server: :environment do
+    # for config options see: https://github.com/NUBIC/ladle/blob/master/lib/ladle/server.rb
     server = Ladle::Server.new(
       port: 3897,
       ldif: Rails.root.join('decidim-ldap', 'lib', 'ladle', 'default.ldif'),


### PR DESCRIPTION
- Corrects a mispelling in the doc of the LDAP module.
- Adds link to Ladle::Server instantiation options.
