### PR TITLE
Add :max_age to AgeActionAuthorization

### DIFF
--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -14,6 +14,7 @@ Decidim.configure do |config|
     auth.action_authorizer = 'Decidim::AgeActionAuthorization::Authorizer'
     auth.options do |options|
       options.attribute :age, type: :string, required: false
+      options.attribute :max_age, type: :string, required: false
     end
   end
 

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -21,6 +21,7 @@ ca:
         fields:
           birthdate: Data de naixement
           age: 'Edat mínima'
+          max_age: 'Edat màxima'
     features:
       proposals:
         actions:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,6 +21,7 @@ en:
         fields:
           birthdate: Date of birth
           age: Minimum age
+          max_age: Maximum age
     features:
       proposals:
         actions:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -21,6 +21,7 @@ es:
         fields:
           birthdate: Fecha de nacimiento
           age: Edad mínima
+          max_age: Edad máxima
     features:
       proposals:
         actions:

--- a/decidim-age_action_authorization/lib/decidim/age_action_authorization/authorizer.rb
+++ b/decidim-age_action_authorization/lib/decidim/age_action_authorization/authorizer.rb
@@ -19,7 +19,14 @@ module Decidim
       end
 
       def valid_age?
-        (birthdate + minimum_age.years) <= Date.current
+        min_date = birthdate + minimum_age.years
+        max_date = (birthdate + options['max_age'].to_i.years if options.key?('max_age'))
+
+        if max_date
+          (min_date..max_date).cover?(Date.current)
+        else
+          min_date <= Date.current
+        end
       end
 
       def birthdate

--- a/decidim-age_action_authorization/spec/decidim/age_action_authorization/authorizer_spec.rb
+++ b/decidim-age_action_authorization/spec/decidim/age_action_authorization/authorizer_spec.rb
@@ -26,6 +26,32 @@ RSpec.describe Decidim::AgeActionAuthorization::Authorizer do
     expect(authorizer_without_authorization.authorize).to include(:missing)
   end
 
+  describe 'when max_age is pressent' do
+    it 'authorizes if is older that :age and yonger that :max_age' do
+      birthdate = 21.years.ago.strftime('%Y/%m/%d')
+      authorizer = authorizer_class.new(authorization_for(birthdate), { 'age' => '20', 'max_age' => '22' }, component, resource)
+      expect(authorizer.authorize).to include(:ok)
+    end
+
+    it 'authorizes if is older that :age and equal that :max_age' do
+      birthdate = 22.years.ago.strftime('%Y/%m/%d')
+      authorizer = authorizer_class.new(authorization_for(birthdate), { 'age' => '20', 'max_age' => '22' }, component, resource)
+      expect(authorizer.authorize).to include(:ok)
+    end
+
+    it 'not authorizes if is older of :max_age' do
+      birthdate = 23.years.ago.strftime('%Y/%m/%d')
+      authorizer = authorizer_class.new(authorization_for(birthdate), { 'age' => '20', 'max_age' => '22' }, component, resource)
+      expect(authorizer.authorize).to include(:unauthorized)
+    end
+
+    it 'not authorizes if is younger of :age' do
+      birthdate = 19.years.ago.strftime('%Y/%m/%d')
+      authorizer = authorizer_class.new(authorization_for(birthdate), { 'age' => '20', 'max_age' => '22' }, component, resource)
+      expect(authorizer.authorize).to include(:unauthorized)
+    end
+  end
+
   def authorization_for(date)
     OpenStruct.new(metadata: { 'birthdate' => date },
                    granted?: true)

--- a/decidim-census/config/locales/ca.yml
+++ b/decidim-census/config/locales/ca.yml
@@ -19,6 +19,7 @@ ca:
         fields:
           birthdate: Data de naixement
           age: 'Edat mínima'
+          max_age: 'Edat máxima'
     census:
       errors:
         messages:

--- a/decidim-census/config/locales/en.yml
+++ b/decidim-census/config/locales/en.yml
@@ -19,6 +19,7 @@ en:
         fields:
           birthdate: Birthdate
           age: 'Minimum age'
+          age: 'Maximum age'
     census:
       errors:
         messages:

--- a/decidim-census/config/locales/es.yml
+++ b/decidim-census/config/locales/es.yml
@@ -19,6 +19,7 @@ es:
         fields:
           birthdate: Fecha de nacimiento
           age: 'Edad mínima'
+          max_age: 'Edad máxima'
     census:
       errors:
         messages:

--- a/decidim-census/lib/decidim/census/engine.rb
+++ b/decidim-census/lib/decidim/census/engine.rb
@@ -19,6 +19,7 @@ module Decidim
           auth.action_authorizer = 'Decidim::AgeActionAuthorization::Authorizer'
           auth.options do |options|
             options.attribute :age, type: :string, required: false
+            options.attribute :max_age, type: :string, required: false
           end
         end
       end

--- a/decidim-diba_census_api/lib/decidim/diba_census_api/engine.rb
+++ b/decidim-diba_census_api/lib/decidim/diba_census_api/engine.rb
@@ -19,6 +19,7 @@ module Decidim
           auth.action_authorizer = 'Decidim::AgeActionAuthorization::Authorizer'
           auth.options do |options|
             options.attribute :age, type: :string, required: false
+            options.attribute :max_age, type: :string, required: false
           end
         end
       end


### PR DESCRIPTION
Besides the min_age parameter, adds a new max_age param to the AgeActionAuthorization. These restrictions can be used independently or being combined.