### PR TITLE
Sincronize homepage wrapper with Decidim 0.18-stable.

### DIFF
--- a/decidim-ldap/app/views/layouts/decidim/_wrapper.html.erb
+++ b/decidim-ldap/app/views/layouts/decidim/_wrapper.html.erb
@@ -73,7 +73,7 @@ end
             <% else %>
               <div class="topbar__user show-for-medium" data-set="nav-login-holder">
                 <div class="topbar__user__login js-append">
-                  <% unless current_organization.ldap? %>
+                  <% if current_organization.sign_up_enabled? || current_organization.ldap? %>
                     <%= link_to t("layouts.decidim.header.sign_up"), decidim.new_user_registration_path, class: "sign-up-link" %>
                   <% end %>
                   <%= link_to t("layouts.decidim.header.sign_in"), decidim.new_user_session_path, class: "sign-in-link" %>
@@ -104,13 +104,20 @@ end
         <% end %>
         <div class="row">
           <div class="medium-8 large-6 large-offset-3 column main__footer__nav">
-            <% if current_organization.static_pages.any? %>
               <ul class="footer-nav">
-                <% current_organization.static_pages.sorted_by_i18n_title.each do |page| %>
-                  <li><%= link_to translated_attribute(page.title), decidim.page_path(page) %></li>
+                <% if current_organization.static_pages.any? %>
+                  <% current_organization.static_page_topics.where(show_in_footer: true).each do |page_topic| %>
+                    <% if page_topic.pages.any? %>
+                      <li><%= link_to translated_attribute(page_topic.title), decidim.page_path(page_topic.pages.first) %></li>
+                    <% end %>
+                  <% end %>
+
+                  <% current_organization.static_pages.where(show_in_footer: true).sorted_by_i18n_title.each do |page| %>
+                    <li><%= link_to translated_attribute(page.title), decidim.page_path(page) %></li>
+                  <% end %>
                 <% end %>
+                <li><%= link_to t("layouts.decidim.footer.download_open_data"), decidim.open_data_download_path %></li>
               </ul>
-            <% end %>
           </div>
           <%= render partial: "layouts/decidim/social_media_links" %>
         </div>


### PR DESCRIPTION
`decidim-ldap` module is overwritting the application layout wrapper file and it is now not syncrhonized with DiBa's current decidim version which is Decidim v0.18-stable.

This caused the following problem:
- When marking static pages to not `show_in_footer`, they were still being rendered in the footer.

This PR solves this problem