### PR TITLE
Update custom Handlers after updating to Decidim v0.19.

### DIFF
--- a/decidim-census/Gemfile.lock
+++ b/decidim-census/Gemfile.lock
@@ -2,13 +2,13 @@ PATH
   remote: ../decidim-age_action_authorization
   specs:
     decidim-age_action_authorization (0.18.0)
-      decidim (= 0.18.0)
+      decidim (>= 0.18.0)
 
 PATH
   remote: ../decidim-ldap
   specs:
     decidim-ldap (0.18.0)
-      decidim-core (= 0.18.0)
+      decidim-core (>= 0.18.0)
       ladle
       net-ldap
 
@@ -16,10 +16,10 @@ PATH
   remote: .
   specs:
     decidim-census (0.18.0)
-      decidim (= 0.18.0)
-      decidim-admin (= 0.18.0)
-      decidim-age_action_authorization (= 0.18.0)
-      decidim-ldap (= 0.18.0)
+      decidim (>= 0.18.0)
+      decidim-admin (>= 0.18.0)
+      decidim-age_action_authorization (>= 0.18.0)
+      decidim-ldap (>= 0.18.0)
       virtus-multiparams (~> 0.1.1)
 
 GEM
@@ -479,7 +479,7 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.1.1)
     mustache (1.1.0)
-    net-ldap (0.16.1)
+    net-ldap (0.16.2)
     netrc (0.11.0)
     nio4r (2.5.2)
     nobspw (0.6.1)
@@ -736,7 +736,7 @@ DEPENDENCIES
   decidim
   decidim-age_action_authorization!
   decidim-census!
-  decidim-dev (= 0.18.0)
+  decidim-dev (>= 0.18.0)
   decidim-ldap!
   faker
   pry-rails

--- a/decidim-census/app/services/census_authorization_handler.rb
+++ b/decidim-census/app/services/census_authorization_handler.rb
@@ -39,6 +39,8 @@ class CensusAuthorizationHandler < Decidim::AuthorizationHandler
   end
 
   def census_for_user
+    return unless organization
+
     @census_for_user ||= Decidim::Census::CensusDatum
                          .search_id_document(organization, id_document)
   end

--- a/decidim-census/spec/services/census_authorization_handler_when_impersonating_spec.rb
+++ b/decidim-census/spec/services/census_authorization_handler_when_impersonating_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+RSpec.describe CensusAuthorizationHandler do
+  subject { handler.unique_id }
+  # let(:organization) { FactoryBot.create(:organization) }
+  # let(:user) { FactoryBot.create(:user, organization: organization) }
+  # let(:dni) { '1234A' }
+  # let(:encoded_dni) { encode_id_document(dni) }
+  # let(:date) { Date.strptime('1990/11/21', '%Y/%m/%d') }
+  let(:handler) do
+    CensusAuthorizationHandler.new
+  end
+
+  context 'when creating a new impersonation' do
+    it { is_expected.to be_nil }
+  end
+end

--- a/decidim-diba_census_api/app/services/diba_census_api_authorization_handler.rb
+++ b/decidim-diba_census_api/app/services/diba_census_api_authorization_handler.rb
@@ -51,6 +51,7 @@ class DibaCensusApiAuthorizationHandler < Decidim::AuthorizationHandler
 
   def census_for_user
     return @census_for_user if defined? @census_for_user
+    return unless organization
 
     @service = DibaCensusApi.new(api_config)
     @census_for_user = @service.call(


### PR DESCRIPTION
As Decidim v0.19 includes commit 69a75d410d185534cf7cb838778411d8b3b8b491 which changes the way `decidim-admin/app/controllers/decidim/admin/impersonations_controller.rb` invokes handlers when creating new impersonations, custom handlers must be updated.

The main problem is the lack of organization when the user is impersonated for the first time.