### PR TITLE
Add already censed message error

### DIFF
--- a/app/services/diba_authorization_handler.rb
+++ b/app/services/diba_authorization_handler.rb
@@ -25,7 +25,13 @@ class DibaAuthorizationHandler < Decidim::AuthorizationHandler
   def censed
     return if diba_handler.valid?
 
-    errors.add(:id_document, I18n.t('decidim.census.errors.messages.not_censed'))
+    if diba_handler.errors.any?
+      diba_handler.errors.entries.each do |key, msg|
+        errors.add(key, msg)
+      end
+    else
+      errors.add(:id_document, I18n.t('decidim.census.errors.messages.not_censed'))
+    end
   end
 
   def diba_handler

--- a/decidim-census/config/locales/ca.yml
+++ b/decidim-census/config/locales/ca.yml
@@ -24,6 +24,7 @@ ca:
     census:
       errors:
         messages:
+          invalid_credentials: Les credencials no coincideixen.
           not_censed: No hem pogut trobar el teu document d'identitat amb aquesta data de naixement al padró municipal. Si les dades són correctes i el problema persisteix, siusplau, posa't en contacte amb un administrador.
           younger_than_minimum_age: Hauries de ser major de %{age} anys
       admin:

--- a/decidim-census/config/locales/en.yml
+++ b/decidim-census/config/locales/en.yml
@@ -24,6 +24,7 @@ en:
     census:
       errors:
         messages:
+          invalid_credentials: Invalid credentials
           not_censed: We could not find your document ID matching with this birthdate in our Census. If the data entered is correct and the problem persists, please, contact an administrator.
           younger_than_minimum_age: You should be older than %{age} years
       admin:

--- a/decidim-census/config/locales/es.yml
+++ b/decidim-census/config/locales/es.yml
@@ -24,6 +24,7 @@ es:
     census:
       errors:
         messages:
+          invalid_credentials: Las credenciales no coinciden.
           not_censed: No hemos podido encontrar tu documento de identidad con esta fecha de nacimiento en el padrón municipal. Si tus datos son correctos y el problema persiste, por favor, ponte en contacto con un administrador
           younger_than_minimum_age: Deberías ser mayor de %{age} años
       admin:

--- a/decidim-diba_census_api/app/services/diba_census_api_authorization_handler.rb
+++ b/decidim-diba_census_api/app/services/diba_census_api_authorization_handler.rb
@@ -36,9 +36,11 @@ class DibaCensusApiAuthorizationHandler < Decidim::AuthorizationHandler
 
   # Checks if the id_document belongs to the census
   def censed
-    return if census_for_user&.birthdate == birthdate
-
-    errors.add(:id_document, I18n.t('decidim.census.errors.messages.not_censed'))
+    if census_for_user.nil?
+      errors.add(:id_document, I18n.t('decidim.census.errors.messages.not_censed'))
+    elsif census_for_user.birthdate != birthdate
+      errors.add(:birthdate, I18n.t('decidim.census.errors.messages.invalid_credentials'))
+    end
   end
 
   def unique_id


### PR DESCRIPTION
The `DibaAuthorizationHandler` was ignoring errors from the handler it delegates to. This diconcerted participants when trying to verify.

Take error messages from delegated handler in order to make form errors less confusing.


Fixes: #45