### PR TITLE
Fix generating a vote in a consultation with a 1 limit vote

### DIFF
--- a/app/views/decidim/consultations/questions/_vote_modal_confirm.html.erb
+++ b/app/views/decidim/consultations/questions/_vote_modal_confirm.html.erb
@@ -1,0 +1,34 @@
+<div class="reveal" data-reveal id="question-vote-confirm-modal">
+  <div class="reveal__header">
+    <h3 class="reveal__title">
+      <%= t "questions.vote_modal_confirm.title", scope: "decidim" %>
+    </h3>
+    <button class="close-button" data-close aria-label="Close modal" type="button">
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </div>
+  <p><%= t "questions.vote_modal_confirm.contextual_help", scope: "decidim" %></p>
+  <div class="card card--secondary">
+    <div class="card__content">
+      <h4 class="heading5 text-center"><%= translated_attribute(question.title).html_safe %></h4>
+      <h5 class="heading6 text-center" id="question-vote-confirm-modal-question-title"></h5>
+    </div>
+  </div>
+  <div class="row">
+    <div class="columns medium-8 medium-offset-2">
+      <%= form_with url: decidim_consultations.question_question_votes_path(question),
+                    id: "confirm-vote-form", data: {remote: true} do |form| %>
+        <%= form.hidden_field :decidim_consultations_response_id, id: "decidim_consultations_response_id" %>
+        <%= form.submit t("questions.vote_modal_confirm.confirm", scope: "decidim"),
+                        class: "button expanded",
+                        data: { disable: true } %>
+      <% end %>
+      <div id="confirm-vote-form-loader" class="loading-spinner hide"></div>
+    </div>
+  </div>
+  <div class="text-center">
+    <button class="link" id="question-vote-confirm-modal-button-change">
+      <%= t "questions.vote_modal_confirm.change", scope: "decidim" %>
+    </button>
+  </div>
+</div>

--- a/docs/overrides.md
+++ b/docs/overrides.md
@@ -105,3 +105,4 @@ checked for incompatibilities.
 **app/views/decidim/consultations/questions/_vote_modal_confirm.html.erb**
 The default view generates a form_with with data remote equals true. But in this project the data remote is not generated due to an Unobstrusive Javascript driver not found.
 The override forces the data-remote to true of the form and then, the rendered view of the response will be a js.erb that exists in Decidim project.
+This malfunction should be reviewed in more detail so that we find the final problem and can get rid of this abnormal override.

--- a/docs/overrides.md
+++ b/docs/overrides.md
@@ -100,3 +100,8 @@ was the best way to implement this feature.
 
 It is using the Decidim internal API to be able to perform the required authorization. Whenever the project is updated this file needs to be
 checked for incompatibilities.
+
+
+**app/views/decidim/consultations/questions/_vote_modal_confirm.html.erb**
+The default view generates a form_with with data remote equals true. But in this project the data remote is not generated due to an Unobstrusive Javascript driver not found.
+The override forces the data-remote to true of the form and then, the rendered view of the response will be a js.erb that exists in Decidim project.


### PR DESCRIPTION
The error appears because the confirm form of the vote is generated without data-remote: true. The commit generates an override of the confirm form view.