### PR TITLE
Fix invitation link to promoter committee

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'decidim-ldap', path: 'decidim-ldap'
 
 # Lock sprockets until decidim supports version 4.
 gem "sprockets", "~> 3.7", "< 4"
-# Compability with decidim initiatives module
+# Compatibility with decidim initiatives module
 gem 'wicked_pdf'
 gem 'letter_opener_web'
 gem 'puma', '>= 3.12.2'

--- a/app/permissions/decidim/initiatives/permissions.rb
+++ b/app/permissions/decidim/initiatives/permissions.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Initiatives
+    class Permissions < Decidim::DefaultPermissions
+      def permissions
+        if read_admin_dashboard_action?
+          user_can_read_admin_dashboard?
+          return permission_action
+        end
+
+        # Delegate the admin permission checks to the admin permissions class
+        return Decidim::Initiatives::Admin::Permissions.new(user, permission_action, context).permissions if permission_action.scope == :admin
+        return permission_action if permission_action.scope != :public
+
+        # Non-logged users permissions
+        public_report_content_action?
+        list_public_initiatives?
+        read_public_initiative?
+        search_initiative_types_and_scopes?
+        request_membership?
+
+        return permission_action unless user
+
+        create_initiative?
+
+        vote_initiative?
+        sign_initiative?
+        unvote_initiative?
+
+        permission_action
+      end
+
+      private
+
+      def initiative
+        @initiative ||= context.fetch(:initiative, nil) || context.fetch(:current_participatory_space, nil)
+      end
+
+      def list_public_initiatives?
+        allow! if permission_action.subject == :initiative &&
+                  permission_action.action == :list
+      end
+
+      def read_public_initiative?
+        return unless [:initiative, :participatory_space].include?(permission_action.subject) &&
+                      permission_action.action == :read
+
+        return allow! if initiative.published? || initiative.rejected? || initiative.accepted?
+        return allow! if user && (initiative.has_authorship?(user) || user.admin?)
+
+        disallow!
+      end
+
+      def search_initiative_types_and_scopes?
+        return unless permission_action.action == :search
+        return unless [:initiative_type, :initiative_type_scope, :initiative_type_signature_types].include?(permission_action.subject)
+
+        allow!
+      end
+
+      def create_initiative?
+        return unless permission_action.subject == :initiative &&
+                      permission_action.action == :create
+
+        toggle_allow(creation_enabled?)
+      end
+
+      def creation_enabled?
+        Decidim::Initiatives.creation_enabled && (
+          Decidim::Initiatives.do_not_require_authorization ||
+            UserAuthorizations.for(user).any? ||
+            Decidim::UserGroups::ManageableUserGroups.for(user).verified.any?
+        )
+      end
+
+      def request_membership?
+        return unless permission_action.subject == :initiative &&
+                      permission_action.action == :request_membership
+
+      can_request = if user
+        !initiative.published? &&
+        !initiative.has_authorship?(user) &&
+        (
+          Decidim::Initiatives.do_not_require_authorization ||
+          UserAuthorizations.for(user).any? ||
+          Decidim::UserGroups::ManageableUserGroups.for(user).verified.any?
+        )
+      else
+        !initiative.published?
+      end
+
+        toggle_allow(can_request)
+      end
+
+      def has_initiatives?
+        (InitiativesCreated.by(user) | InitiativesPromoted.by(user)).any?
+      end
+
+      def read_admin_dashboard_action?
+        permission_action.action == :read &&
+          permission_action.subject == :admin_dashboard
+      end
+
+      def user_can_read_admin_dashboard?
+        return unless user
+
+        allow! if has_initiatives?
+      end
+
+      def vote_initiative?
+        return unless permission_action.action == :vote &&
+                      permission_action.subject == :initiative
+
+        toggle_allow(can_vote?)
+      end
+
+      def authorized?(permission_action, resource: nil, permissions_holder: nil)
+        return unless resource || permissions_holder
+
+        ActionAuthorizer.new(user, permission_action, permissions_holder, resource).authorize.ok?
+      end
+
+      def unvote_initiative?
+        return unless permission_action.action == :unvote &&
+                      permission_action.subject == :initiative
+
+        can_unvote = initiative.accepts_online_unvotes? &&
+                     initiative.organization&.id == user.organization&.id &&
+                     initiative.votes.where(decidim_author_id: user.id, decidim_user_group_id: decidim_user_group_id).any? &&
+                     (can_user_support?(initiative) || Decidim::UserGroups::ManageableUserGroups.for(user).verified.any?) &&
+                     authorized?(:vote, resource: initiative, permissions_holder: initiative.type)
+
+        toggle_allow(can_unvote)
+      end
+
+      def public_report_content_action?
+        return unless permission_action.action == :create &&
+                      permission_action.subject == :moderation
+
+        allow!
+      end
+
+      def sign_initiative?
+        return unless permission_action.action == :sign_initiative &&
+                      permission_action.subject == :initiative
+
+        can_sign = can_vote? &&
+                   context.fetch(:signature_has_steps, false)
+
+        toggle_allow(can_sign)
+      end
+
+      def decidim_user_group_id
+        context.fetch(:group_id, nil)
+      end
+
+      def can_vote?
+        initiative.votes_enabled? &&
+          initiative.organization&.id == user.organization&.id &&
+          initiative.votes.where(decidim_author_id: user.id, decidim_user_group_id: decidim_user_group_id).empty? &&
+          (can_user_support?(initiative) || Decidim::UserGroups::ManageableUserGroups.for(user).verified.any?) &&
+          authorized?(:vote, resource: initiative, permissions_holder: initiative.type)
+      end
+
+      def can_user_support?(initiative)
+        !initiative.offline? && (
+          Decidim::Initiatives.do_not_require_authorization ||
+          UserAuthorizations.for(user).any?
+        )
+      end
+    end
+  end
+end

--- a/docs/overrides.md
+++ b/docs/overrides.md
@@ -80,6 +80,10 @@ files invalid.
 
 Before upgrading the platform those keys need to be checked together with the other language files.
 
+## Permissions
+
+To allow non signed in users to be invited to the promoter committee of an initiative https://github.com/decidim/decidim/pull/6115 has been ported to the current decidim v0.19.1 version as an override. This override can be found at `app/permissions/decidim/initiatives/permissions.rb` and can be removed when in Decidim v0.22.
+
 ## Authorization 
 
 The application has 3 custom AuthorizationHandlers. If the Decidim API for AuthorizationHandlers

--- a/docs/overrides.md
+++ b/docs/overrides.md
@@ -1,4 +1,4 @@
-## Overrides
+# Overrides
 
 This document lists all the overrides that have been done at the Decidim platform. Those
 overrides can conflict with platform updates. During a platform upgrade they need to be compared
@@ -7,7 +7,7 @@ to the ones of the Decidim project.
 The best way to spot these problems is revewing the changes in the files that are overriden
 using git history and apply the changes manually.
 
-### Controllers
+## Controllers
 
 **Decidim::Devise::SessionsController**
 
@@ -19,20 +19,19 @@ to enable LDAP authentication strategy for ldap configured organizations.
 The module `Decidim::Ldap::Extensions::RegistrationsControllerWithLdap` is being included in the controller
 to disable signup for ldap configured organizations.
 
-### Views
+## Views
 
 **decidim-ldap/app/views/decidim/devise/sessions/new.html.erb**
 
-It renders the [decidim-ldap/app/views/decidim/devise/sessions/_default.html.erb](/decidim-ldap/app/views/decidim/devise/sessions/_default.html.erb) or the
-[decidim-ldap/app/views/decidim/devise/sessions/_ldap.html.erb](/decidim-ldap/app/views/decidim/devise/sessions/_ldap.html.erb) depending on the organization LDAP
-configurations.
+It renders the [decidim-ldap/app/views/decidim/devise/sessions/\_default.html.erb](/decidim-ldap/app/views/decidim/devise/sessions/_default.html.erb) or the
+[decidim-ldap/app/views/decidim/devise/sessions/\_ldap.html.erb](/decidim-ldap/app/views/decidim/devise/sessions/_ldap.html.erb) depending on the organization LDAP configurations.
 
-The _default.html partial must contain the same HTML found in the overriden new.html.erb
+The \_default.html partial must contain the same HTML found in the overriden new.html.erb
 except for the following changes:
 
 - The I18n keys must not be relative. They need to include the absolute route from the original file.
 
-The _ldap.html.erb file adds the following changes:
+The \_ldap.html.erb file adds the following changes:
 
 - Replace email field for name field
 - Remove signup link and social login links
@@ -40,9 +39,8 @@ The _ldap.html.erb file adds the following changes:
 
 **decidim-ldap/app/views/decidim/shared/login_modal.html.erb**
 
-It renders the [decidim-ldap/app/views/decidim/shared/_login_modal_default.html.erb](/decidim-ldap/app/views/decidim/shared/_login_modal_default.html.erb) or the
-[decidim-ldap/app/views/decidim/shared/_login_modal_ldap.html.erb](/decidim-ldap/app/views/decidim/shared/_login_modal_ldap.html.erb) depending on the organization LDAP
-configurations.
+It renders the [decidim-ldap/app/views/decidim/shared/\_login_modal_default.html.erb](/decidim-ldap/app/views/decidim/shared/_login_modal_default.html.erb) or the
+[decidim-ldap/app/views/decidim/shared/\_login_modal_ldap.html.erb](/decidim-ldap/app/views/decidim/shared/_login_modal_ldap.html.erb) depending on the organization LDAP configurations.
 
 It includes the same changes found in the previous file (devise/sessions/new.html)
 
@@ -55,14 +53,20 @@ It modifies the lines 76 to 78 to remove the signup link for ldap enabled organi
 Starting at line 26, a new behaviour has been included to show custom error messages to the custom action authorizer created for
 the project.
 
-### Helpers
+**app/views/decidim/consultations/questions/\_vote_modal_confirm.html.erb**
+
+The default view generates a form_with with data remote equals true. But in this project the data remote is not generated due to an Unobstrusive Javascript driver not found.
+The override forces the data-remote to true of the form and then, the rendered view of the response will be a js.erb that exists in Decidim project.
+This malfunction should be reviewed in more detail so that we find the final problem and can get rid of this abnormal override.
+
+## Helpers
 
 **app/helpers/application_helper.rb**
 
 This file is not overriding any Decidim behaviour, but it's using Decidim internal instance variables to be able to show custom error messages
 for the decidim age action authorizer. Whenever a new upgrade is applied, it's recommended to check if the code still works as expected.
 
-### Locales
+## Locales
 
 This Decidim installation replaces the Assemblies text for Participatory committees. These
 changes can be found in the following files:
@@ -76,7 +80,7 @@ files invalid.
 
 Before upgrading the platform those keys need to be checked together with the other language files.
 
-### Authorization & Permissions
+## Authorization 
 
 The application has 3 custom AuthorizationHandlers. If the Decidim API for AuthorizationHandlers
 changes, they need to be reviewed.
@@ -100,9 +104,3 @@ was the best way to implement this feature.
 
 It is using the Decidim internal API to be able to perform the required authorization. Whenever the project is updated this file needs to be
 checked for incompatibilities.
-
-
-**app/views/decidim/consultations/questions/_vote_modal_confirm.html.erb**
-The default view generates a form_with with data remote equals true. But in this project the data remote is not generated due to an Unobstrusive Javascript driver not found.
-The override forces the data-remote to true of the form and then, the rendered view of the response will be a js.erb that exists in Decidim project.
-This malfunction should be reviewed in more detail so that we find the final problem and can get rid of this abnormal override.

--- a/spec/features/remove_overrides_spec.rb
+++ b/spec/features/remove_overrides_spec.rb
@@ -1,0 +1,8 @@
+require "rails_helper"
+
+RSpec.describe "Overrides" do
+  scenario "remove override to allow non signed in users to be invited to the promoter committee" do
+    # remove app/permissions/decidim/initiatives/permissions.rb, see docs/overrides.md for details
+    expect(Decidim.version).to be < "0.22"
+  end
+end


### PR DESCRIPTION
To allow non signed in users to be invited to the promoter committee of an initiative https://github.com/decidim/decidim/pull/6115 has been ported to the current version (decidim v0.19.1) as an override. 