### PR TITLE
Fix census handler user's authorization issue

### DIFF
--- a/decidim-census/app/services/census_authorization_handler.rb
+++ b/decidim-census/app/services/census_authorization_handler.rb
@@ -27,11 +27,6 @@ class CensusAuthorizationHandler < Decidim::AuthorizationHandler
   attribute :postal_code, String
   attribute :scope_id, Integer
 
-  validates :document_number, format: { with: /\A[A-z0-9]*\z/ }, presence: true
-  validates :date_of_birth, presence: true
-  validates :postal_code, presence: true, format: { with: /\A[0-9]*\z/ }
-  validates :scope_id, presence: true
-
   def metadata
     { birthdate: census_for_user&.birthdate&.strftime('%Y/%m/%d') }
   end


### PR DESCRIPTION
#### :tophat: What? Why?

Due to this #80 issue, an bug was introduced in user authorization process because user's authorization process and users initiative sign uses same census handler but with different parameter names depending on in which workflow the handler is being used.