### PR TITLE
Fix replace locator param

### DIFF
--- a/app/overrides/add_custom_error_messages_in_authorization_modals.rb
+++ b/app/overrides/add_custom_error_messages_in_authorization_modals.rb
@@ -1,7 +1,7 @@
 unless ActiveModel::Type::Boolean.new.cast(ENV['DOCKER'])
   Deface::Override.new(virtual_path: 'decidim/authorization_modals/_content',
                        name: 'add_custom_error_messages_in_authorization_modals',
-                       replace: '<li>',
+                       replace: 'li',
                        text: '
                         <% case field %>
                           <% when :birthdate %>


### PR DESCRIPTION
The replace locator param should be `li` instead of `<li>`.