### PR TITLE
Add :fr and :de to Decidim.available_locales

### DIFF
--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -28,7 +28,8 @@ Decidim.configure do |config|
   Decidim::Verifications::WorkflowManifest.prepend(WorkflowManifestExtension)
 
   # Uncomment this lines to set your preferred locales
-  config.available_locales = [:ca, :es, :en]
+  config.default_locale = :ca
+  config.available_locales = [:ca, :es, :en, :fr, :de]
 
   # Geocoder configuration
   # geocoder_config = Rails.application.secrets.geocoder


### PR DESCRIPTION
This PR adds French and German locales to Decidim's available locales. Then, each organization will have these two more languages to choose for enabling.