### PR TITLE
Configure RackAttack throttling

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,12 @@ When signing in, the following fields from the `default.ldif` should ve used:
 To publish to docker hub:
 
 ```
-DIBA_DOCKER_TAG=diputaciobcn/decidim-diba:v13.0.5-decidim_0.26.4
-docker build -f Dockerfile.production -t $DIBA_DOCKER_TAG .
+DIBA_TAG=v13.0.6-decidim_0.26.4
+DIBA_DOCKER_TAG=diputaciobcn/decidim-diba:$DIBA_TAG
+docker build -f --network=host Dockerfile.production -t $DIBA_DOCKER_TAG .
 docker tag $DIBA_DOCKER_TAG diputaciobcn/decidim-diba:latest
 docker push $DIBA_DOCKER_TAG
 docker push diputaciobcn/decidim-diba:latest
+git tag -a $DIBA_TAG -m $DIBA_TAG
+git push origin $DIBA_TAG
 ```

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ To publish to docker hub:
 ```
 DIBA_TAG=v13.0.6-decidim_0.26.4
 DIBA_DOCKER_TAG=diputaciobcn/decidim-diba:$DIBA_TAG
-docker build -f --network=host Dockerfile.production -t $DIBA_DOCKER_TAG .
+docker build --network=host -f Dockerfile.production -t $DIBA_DOCKER_TAG .
 docker tag $DIBA_DOCKER_TAG diputaciobcn/decidim-diba:latest
 docker push $DIBA_DOCKER_TAG
 docker push diputaciobcn/decidim-diba:latest

--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -10,9 +10,6 @@ Decidim.configure do |config|
   # Whether SSL should be enabled or not.
   config.force_ssl = false
 
-  # Whether SSL should be enabled or not.
-  config.force_ssl = false
-
   # Reset default workflows
   Decidim::Verifications.clear_workflows
 
@@ -39,6 +36,12 @@ Decidim.configure do |config|
   #     here_app_code: geocoder_config[:here_app_code]
   #   }
   # end
+
+  # Max requests in a time period to prevent DoS attacks. Only applied on production.
+  config.throttling_max_requests = Rails.application.secrets.decidim[:throttling_max_requests].to_i
+
+  # Time window in which the throttling is applied.
+  config.throttling_period = Rails.application.secrets.decidim[:throttling_period].to_i.minutes
 end
 
 Decidim::Ldap.configure do |config|

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -10,7 +10,13 @@
 # Make sure the secrets in this file are kept private
 # if you're sharing your code publicly.
 
+decidim_default: &decidim_default
+  throttling_max_requests: <%= ENV["DECIDIM_THROTTLING_MAX_REQUESTS"].to_i %>
+  throttling_period: <%= ENV["DECIDIM_THROTTLING_PERIOD"].to_i %>
+
 default: &default
+  decidim:
+    <<: *decidim_default
   omniauth:
     facebook:
       # It must be a boolean. Remember ENV variables doesn't support booleans.


### PR DESCRIPTION
Decidim's default Throttling is too small. This PR allows to change the throttling via environment variables avoiding having to rebuild.