### PR TITLE
Override Decidim's editor code with empty file

### DIFF
--- a/app/packs/src/decidim/editor.js
+++ b/app/packs/src/decidim/editor.js
@@ -1,0 +1,4 @@
+/**
+* Override Decidim's editor so it is not executed.does not modify our config.
+*/
+// const noop = () => {};


### PR DESCRIPTION
Unexpectedly decidim-awesome was not overriding Decidim's Quill related code so the editor related code was being executed twice.

As Decidim does not support `align` related formats and Decidim's `editor.js` was being executed first, alignment related classes (like `ql-align-justify`) were being removed from the input field making the styles disappear.