### PR TITLE
Increase SMTP timeouts

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -41,7 +41,9 @@ Rails.application.configure do
     port: Rails.application.secrets.smtp_port,
     domain: Rails.application.secrets.smtp_domain,
     enable_starttls_auto: Rails.application.secrets.smtp_starttls_auto,
-    openssl_verify_mode: "none"
+    openssl_verify_mode: "none",
+    open_timeout: 30,
+    read_timeout: 60
   }.tap do |settings|
     # Net::SMTP only accepts :plain, :login, :cram_md5. Omit auth when "none" or blank.
     if smtp_auth.blank? || smtp_auth == "none"


### PR DESCRIPTION
SMTP timeouts are causing Sidekiq jobs to retry, and might cause duplicate email deliveries.

SMTP timeout default value (5s) is too tighted to production SMTP response times (which is around 5.5s - 7s). 

This PR increases open and read timeout to prevent the re-delivery.

